### PR TITLE
prettierとeslintの設定を追加

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset'
-  ]
-}
+  presets: ['@vue/cli-plugin-babel/preset']
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "format": "prettier --write \"**/*.{js,json}\"",
+    "fix": "npm run format && npm run lint"
   },
   "dependencies": {
     "core-js": "^3.6.5",

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-import Vue from 'vue'
-import App from './App.vue'
+import Vue from 'vue';
+import App from './App.vue';
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 new Vue({
-  render: h => h(App),
-}).$mount('#app')
+  render: h => h(App)
+}).$mount('#app');


### PR DESCRIPTION
いろいろと右往左往したが、ひとまず下記2行を追加

```
"format": "prettier --write \"**/*.{js,json}\"",
    "fix": "npm run format && npm run lint"
```

-----------

エラーで色々と試したこと

`--save-dev`はlocal install

https://qiita.com/heyheyww/items/092fcbc490a249a2d05c



npmで管理しているライブラリのバージョンアップ手順まとめ

https://qiita.com/yoshii0110/items/5f90f9c8ea77d70d5204



eslint (npm version)

https://www.npmjs.com/package/eslint



prettier eslint 設定

https://qiita.com/diggy-mo/items/bb01bcb54237f16bb008



ESLintで Parsing error: Unexpected token = となる場合の対処法

https://qiita.com/kurkuru/items/d4eebd34f0898c6a2d5a

vueでのケースも同様。

eslint eslint-plugin-vueを入れ直す

https://qiita.com/sugasaki/items/983544d220d22201a44d

→コードは解決。



※eslint-config-prettier



今度はこんなエラー

```
Error: Failed to load config "prettier" to extend from.
Referenced from: /Users/Tomohiro/dev/vue-on-storybook/.eslintrc
```

おそらく書き方の問題

→https://bit.ly/3AdgxpT



eslint-config-prettierをversion downしてinstallして、eslintrcの設定を試みたが、うまくいかなかった。



eslintを

eslintのバージョン確認

```
eslint -v
v6.8.0
```



eslntの最新バージョン確認

```
npm view eslint version

```



今入れてるeslintをアンインストール

```
yarn remove eslint
```



eslint最新版を追加 publicかどうか確認済

eslintの依存関係もアップデートされる

```
yarn add -D eslint
success Saved 25 new dependencies.
```

dependencies問題はあまり深入りしないこと。
元々準備されているversionを活かすことを考える。


※Macbook一つあとの操作に戻す
command + y 

